### PR TITLE
Improved search

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -31,10 +31,8 @@ jobs:
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v3
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build
+      - name: Build with gradle
+        run: ./gradlew build
       - uses: actions/upload-artifact@v4
         with:
           name: javadoc-viewer-jar

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: javadoc-viewer-jar
           path: build/libs

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Publish snapshot
         uses: gradle/gradle-build-action@v2
         with:
@@ -25,7 +25,7 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: javadoc-viewer-release-jar
           path: build/libs

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Publish snapshot
         uses: gradle/gradle-build-action@v2
         with:
@@ -24,7 +24,7 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: javadoc-viewer-snapshot-jar
           path: build/libs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 java = "21"
 slf4j = "2.0.7"
-javafx = "20"
+javafx = "21.0.6"
 javafxPlugin = "0.1.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-java = "17"
+java = "21"
 slf4j = "2.0.7"
 javafx = "20"
 javafxPlugin = "0.1.0"

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/Javadoc.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/Javadoc.java
@@ -116,12 +116,15 @@ public record Javadoc(URI uri, List<JavadocElement> elements) {
                         name = nameMatcher.group(1) + "." + name;
                     }
                     String link = javadocURI + uriMatcher.group(1);
+                    String category = categoryMatcher.group(1);
+
+                    name = correctNameIfConstructor(name, category);
 
                     try {
                         elements.add(new JavadocElement(
                                 new URI(link),
                                 name,
-                                categoryMatcher.group(1)
+                                category
                         ));
                     } catch (URISyntaxException e) {
                         logger.debug("Cannot create URI {} of Javadoc element", link, e);
@@ -189,6 +192,17 @@ public record Javadoc(URI uri, List<JavadocElement> elements) {
             return lines.collect(Collectors.joining("\n"));
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private static String correctNameIfConstructor(String name, String category) {
+        // Constructor are usually written in the following way: "Class.Class(Parameter)"
+        // This function transforms them into "Class(Parameter)"
+        if (category.equals("Constructor")) {
+            int pointIndex = name.indexOf(".");
+            return name.substring(pointIndex + 1);
+        } else {
+            return name;
         }
     }
 }

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/JavadocElement.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/JavadocElement.java
@@ -5,8 +5,8 @@ import java.net.URI;
 /**
  * An element (function, class, enum...) of a Javadoc.
  *
- * @param uri  the URI of the Javadoc owning this element
- * @param name  the name of the element (e.g. the function name)
- * @param category  the category of the element (e.g. "function")
+ * @param uri the URI of the Javadoc owning this element
+ * @param name the name of the element (e.g. the function name)
+ * @param category the category of the element (e.g. "function" or "class")
  */
 public record JavadocElement(URI uri, String name, String category) {}

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/Utils.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/core/Utils.java
@@ -1,0 +1,26 @@
+package qupath.ui.javadocviewer.core;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * A collection of utility functions.
+ */
+class Utils {
+
+    private static final List<String> WEBSITE_SCHEMES = List.of("http", "https");
+
+    private Utils() {
+        throw new AssertionError("This class is not instantiable.");
+    }
+
+    /**
+     * Indicate whether the provided URI links to a website.
+     *
+     * @param uri the URI to check
+     * @return whether the provided URI links to a website
+     */
+    public static boolean doesUrilinkToWebsite(URI uri) {
+        return uri.getScheme() != null && WEBSITE_SCHEMES.contains(uri.getScheme());
+    }
+}

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompleteTextFieldEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompleteTextFieldEntry.java
@@ -3,7 +3,7 @@ package qupath.ui.javadocviewer.gui.components;
 /**
  * An entry to a {@link AutoCompletionTextField}.
  */
-public interface AutoCompleteTextFieldEntry {
+public interface AutoCompleteTextFieldEntry extends Comparable<AutoCompleteTextFieldEntry> {
 
     /**
      * @return the text that should be displayed by this entry

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -17,7 +17,12 @@ import java.util.stream.Stream;
 
 /**
  * A {@link TextField} that provides suggestions on a context menu.
+ * <p>
  * Suggestions are grouped by category and must implement {@link AutoCompleteTextFieldEntry}.
+ * <p>
+ * Suggestions are sorted according to their order.
+ * <p>
+ * No more than {@link #MAX_ENTRIES} suggestions are displayed at a time.
  *
  * @param <T> the type of suggestions
  */
@@ -69,6 +74,7 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
                 populatePopup(
                         suggestions.stream()
                                 .filter(entry -> entry.getSearchableText().toLowerCase().contains(loweredCaseEnteredText))
+                                .sorted()
                                 .limit(MAX_ENTRIES)
                                 .toList(),
                         enteredText
@@ -109,7 +115,7 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
             // Add first item, show popup, and then add other items
             // This is used to avoid the popup to ignore the anchor position
             // See https://stackoverflow.com/a/58542568
-            entriesPopup.getItems().add(items.get(0));
+            entriesPopup.getItems().add(items.getFirst());
             entriesPopup.show(this, Side.BOTTOM, 0, 0);
             entriesPopup.getItems().addAll(items.stream().skip(1).toList());
         }

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
  * A {@link TextField} that provides suggestions on a context menu.
  * Suggestions are grouped by category and must implement {@link AutoCompleteTextFieldEntry}.
  *
- * @param <T>  the type of suggestions
+ * @param <T> the type of suggestions
  */
 public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> extends TextField {
 

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -12,6 +12,7 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -71,10 +72,15 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
             } else {
                 String loweredCaseEnteredText = enteredText.toLowerCase();
 
+                Comparator<AutoCompleteTextFieldEntry> comparator =
+                        Comparator.comparing((AutoCompleteTextFieldEntry e) -> e.getSearchableText().toLowerCase().equals(loweredCaseEnteredText) ? -1 : 1)
+                                .thenComparing(e -> e.getSearchableText().toLowerCase().startsWith(loweredCaseEnteredText) ? -1 : 1)
+                                .thenComparing(AutoCompleteTextFieldEntry::compareTo);
+
                 populatePopup(
                         suggestions.stream()
                                 .filter(entry -> entry.getSearchableText().toLowerCase().contains(loweredCaseEnteredText))
-                                .sorted()
+                                .sorted(comparator)
                                 .limit(MAX_ENTRIES)
                                 .toList(),
                         enteredText

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -97,7 +97,7 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
                             entries.stream()
                                     .filter(entry -> entry.getCategory().equals(category))
                                     .map(entry -> {
-                                        MenuItem menuItem = new CustomMenuItem(createEntryItemText(entry.getName(), filter), true);
+                                        MenuItem menuItem = new CustomMenuItem(createEntryItemText(entry, filter), true);
 
                                         menuItem.setOnAction(actionEvent -> {
                                             setText(entry.getName());
@@ -127,8 +127,12 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
         return text;
     }
 
-    private static Node createEntryItemText(String text, String filter) {
-        int filterIndex = text.toLowerCase().indexOf(filter.toLowerCase());
+    private Node createEntryItemText(T entry, String filter) {
+        String searchableText = entry.getSearchableText();
+        String text = entry.getName();
+
+        int searchableTextIndex = text.indexOf(searchableText);
+        int filterIndex = text.toLowerCase().indexOf(filter.toLowerCase(), searchableTextIndex);
 
         Text textBefore = new Text(text.substring(0, filterIndex));
         Text textFiltered = new Text(text.substring(filterIndex,  filterIndex + filter.length()));

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
  */
 public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> extends TextField {
 
-    private static final int MAX_ENTRIES = 50;
+    private static final int MAX_ENTRIES = 100;
     private static final int MAX_POPUP_HEIGHT = 300;
     private final ContextMenu entriesPopup = new ContextMenu();
     private final List<T> suggestions = new ArrayList<>();

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/components/AutoCompletionTextField.java
@@ -100,8 +100,6 @@ public class AutoCompletionTextField<T extends AutoCompleteTextFieldEntry> exten
                                         MenuItem menuItem = new CustomMenuItem(createEntryItemText(entry, filter), true);
 
                                         menuItem.setOnAction(actionEvent -> {
-                                            setText(entry.getName());
-                                            positionCaret(entry.getName().length());
                                             entriesPopup.hide();
                                             entry.onSelected();
                                         });

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
@@ -3,6 +3,8 @@ package qupath.ui.javadocviewer.gui.viewer;
 import qupath.ui.javadocviewer.gui.components.AutoCompleteTextFieldEntry;
 import qupath.ui.javadocviewer.core.JavadocElement;
 
+import java.util.Map;
+
 /**
  * An {@link AutoCompleteTextFieldEntry} that represents a {@link JavadocElement}.
  */
@@ -46,5 +48,33 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
     @Override
     public void onSelected() {
         onSelected.run();
+    }
+
+    @Override
+    public int compareTo(AutoCompleteTextFieldEntry otherEntry) {
+        Map<String, Integer> order = Map.of(
+                "Class", 1,
+                "Interface", 2,
+                "Enum", 3,
+                "Constructor", 4,
+                "Static", 5,
+                "Method", 6,
+                "Variable", 7,
+                "Exception", 8,
+                "Annotation", 9,
+                "Element", 10     // display categories in that order
+        );
+
+        int categoryComparison = order.getOrDefault(getCategory(), 0) - order.getOrDefault(otherEntry.getCategory(), 0);
+        if (categoryComparison != 0) {
+            return categoryComparison;
+        }
+
+        return getName().compareTo(otherEntry.getName());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Javadoc entry of %s", javadocElement);
     }
 }

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
@@ -55,7 +55,7 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
                     }
                     yield javadocElement.name();
                 }
-                // expect "Class.Class(Parameter)" for constructors or "Class.function(Parameter) for functions. Retain "Class" or "function"
+                // expect "Class.Class(Parameter)" for constructors or "Class.function(Parameter)" for functions. Retain "Class" or "function"
                 case "Constructor", "Static", "Method" -> {
                     int pointIndex = javadocElement.name().indexOf(".");
                     int parenthesisIndex = javadocElement.name().indexOf("(");

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
@@ -55,8 +55,8 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
                     }
                     yield javadocElement.name();
                 }
-                // expect "Class.Class(Parameter)" for constructors or "Class.function(Parameter)" for functions. Retain "Class" or "function"
-                case "Constructor", "Static", "Method" -> {
+                // expect "Class.function(Parameter)". Retain "function"
+                case "Static", "Method" -> {
                     int pointIndex = javadocElement.name().indexOf(".");
                     int parenthesisIndex = javadocElement.name().indexOf("(");
 
@@ -64,6 +64,16 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
                         yield javadocElement.name().substring(pointIndex+1, parenthesisIndex);
                     } else {
                         yield javadocElement.name().substring(pointIndex+1);
+                    }
+                }
+                // expect "Class(Parameter)". Retain "Class"
+                case "Constructor" -> {
+                    int parenthesisIndex = javadocElement.name().indexOf("(");
+
+                    if (parenthesisIndex > -1) {
+                        yield javadocElement.name().substring(0, parenthesisIndex);
+                    } else {
+                        yield javadocElement.name();
                     }
                 }
                 default -> javadocElement.name();

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
@@ -43,7 +43,7 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
         if (searchableText == null) {
             searchableText = switch (javadocElement.category()) {
                 // expect "some.package.Class". Retain "Class"
-                case "Class", "Interface" -> javadocElement.name().substring(javadocElement.name().indexOf(".") + 1);
+                case "Class", "Interface" -> javadocElement.name().substring(javadocElement.name().lastIndexOf(".") + 1);
                 // expects "some.package.Class.Enum" or "Class.Enum.variable". Retain "Class.Enum" or "Enum.variable"
                 case "Enum" -> {
                     int lastPointIndex = javadocElement.name().lastIndexOf(".");

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocEntry.java
@@ -14,8 +14,8 @@ class JavadocEntry implements AutoCompleteTextFieldEntry {
     /**
      * Create a Javadoc entry from a Javadoc element.
      *
-     * @param javadocElement  the javadoc element to represent
-     * @param onSelected  a function to call when this element is selected
+     * @param javadocElement the javadoc element to represent
+     * @param onSelected a function to call when this element is selected
      */
     public JavadocEntry(JavadocElement javadocElement, Runnable onSelected) {
         this.javadocElement = javadocElement;

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
@@ -35,6 +35,7 @@ public class JavadocViewer extends BorderPane {
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("qupath.ui.javadocviewer.strings");
     private static final Pattern REDIRECTION_PATTERN = Pattern.compile("window\\.location\\.replace\\(['\"](.*?)['\"]\\)");
+    private static final List<String> CATEGORIES_TO_SKIP = List.of("package", "module");
     private final WebView webView = new WebView();
     @FXML
     private Button back;
@@ -141,7 +142,7 @@ public class JavadocViewer extends BorderPane {
                             javadocElement,
                             () -> webView.getEngine().load(javadocElement.uri().toString())
                     ))
-                    .sorted(Comparator.comparing(JavadocEntry::getName))
+                    .filter(javadocEntry -> !CATEGORIES_TO_SKIP.contains(javadocEntry.getCategory()))
                     .toList());
         }));
     }

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
@@ -20,6 +20,7 @@ import qupath.ui.javadocviewer.core.JavadocsFinder;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -57,7 +58,7 @@ public class JavadocViewer extends BorderPane {
      * @throws IOException if the window creation fails
      */
     public JavadocViewer(ReadOnlyStringProperty stylesheet, URI... urisToSearch) throws IOException {
-        initUI(stylesheet, urisToSearch);
+        initUI(stylesheet, Arrays.stream(urisToSearch).toList());
         setUpListeners();
     }
 
@@ -80,7 +81,7 @@ public class JavadocViewer extends BorderPane {
         offset(1);
     }
 
-    private void initUI(ReadOnlyStringProperty stylesheet, URI[] urisToSearch) throws IOException {
+    private void initUI(ReadOnlyStringProperty stylesheet, List<URI> urisToSearch) throws IOException {
         FXMLLoader loader = new FXMLLoader(JavadocViewer.class.getResource("javadoc_viewer.fxml"), resources);
         loader.setRoot(this);
         loader.setController(this);
@@ -118,7 +119,7 @@ public class JavadocViewer extends BorderPane {
         }
 
         webView.getEngine().loadContent(resources.getString("JavadocViewer.findingJavadocs"));
-        JavadocsFinder.findJavadocs(urisToSearch).thenAccept(javadocs -> Platform.runLater(() -> {
+        JavadocsFinder.findJavadocs(urisToSearch.toArray(new URI[0])).thenAccept(javadocs -> Platform.runLater(() -> {
             this.uris.getItems().setAll(javadocs.stream()
                     .map(Javadoc::uri)
                     .sorted(Comparator.comparing(JavadocViewer::getName))

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
@@ -36,7 +36,7 @@ public class JavadocViewer extends BorderPane {
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("qupath.ui.javadocviewer.strings");
     private static final Pattern REDIRECTION_PATTERN = Pattern.compile("window\\.location\\.replace\\(['\"](.*?)['\"]\\)");
-    private static final List<String> CATEGORIES_TO_SKIP = List.of("package", "module");
+    private static final List<String> CATEGORIES_TO_SKIP = List.of("package", "module", "Variable", "Exception", "Annotation", "Element");
     private final WebView webView = new WebView();
     @FXML
     private Button back;

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewer.java
@@ -50,10 +50,10 @@ public class JavadocViewer extends BorderPane {
     /**
      * Create the javadoc viewer.
      *
-     * @param stylesheet  a property containing a link to a stylesheet which should
-     *                    be applied to this viewer. Can be null
-     * @param urisToSearch  URIs to search for Javadocs. See {@link JavadocsFinder#findJavadocs(URI...)}
-     * @throws IOException when the window creation fails
+     * @param stylesheet a property containing a link to a stylesheet which should
+     *                   be applied to this viewer. Can be null
+     * @param urisToSearch URIs to search for Javadocs. See {@link JavadocsFinder#findJavadocs(URI...)}
+     * @throws IOException if the window creation fails
      */
     public JavadocViewer(ReadOnlyStringProperty stylesheet, URI... urisToSearch) throws IOException {
         initUI(stylesheet, urisToSearch);
@@ -62,7 +62,8 @@ public class JavadocViewer extends BorderPane {
 
     /**
      * Set the search text field to an input query.
-     * @param input The search query string.
+     *
+     * @param input the search query string.
      */
     public void setSearchInput(String input) {
         autoCompletionTextField.setText(input);
@@ -117,9 +118,8 @@ public class JavadocViewer extends BorderPane {
 
         webView.getEngine().loadContent(resources.getString("JavadocViewer.findingJavadocs"));
         JavadocsFinder.findJavadocs(urisToSearch).thenAccept(javadocs -> Platform.runLater(() -> {
-
             this.uris.getItems().setAll(javadocs.stream()
-                    .map(Javadoc::getUri)
+                    .map(Javadoc::uri)
                     .sorted(Comparator.comparing(JavadocViewer::getName))
                     .toList()
             );
@@ -130,12 +130,12 @@ public class JavadocViewer extends BorderPane {
                 this.uris.getSelectionModel().select(this.uris.getItems().stream()
                         .filter(u -> getName(u).toLowerCase().contains("qupath"))
                         .findFirst()
-                        .orElse(this.uris.getItems().get(0))
+                        .orElse(this.uris.getItems().getFirst())
                 );
             }
 
             autoCompletionTextField.getSuggestions().addAll(javadocs.stream()
-                    .map(Javadoc::getElements)
+                    .map(Javadoc::elements)
                     .flatMap(List::stream)
                     .map(javadocElement -> new JavadocEntry(
                             javadocElement,

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewerCommand.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewerCommand.java
@@ -6,6 +6,8 @@ import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
 import java.util.ResourceBundle;
 
 /**
@@ -17,7 +19,7 @@ public class JavadocViewerCommand implements Runnable {
     private static final ResourceBundle resources = ResourceBundle.getBundle("qupath.ui.javadocviewer.strings");
     private final Stage owner;
     private final ReadOnlyStringProperty stylesheet;
-    private final URI[] urisToSearch;
+    private final List<URI> urisToSearch;
     private Stage stage;
     private JavadocViewer javadocViewer;
 
@@ -32,7 +34,7 @@ public class JavadocViewerCommand implements Runnable {
     public JavadocViewerCommand(Stage owner, ReadOnlyStringProperty stylesheet, URI... urisToSearch) {
         this.owner = owner;
         this.stylesheet = stylesheet;
-        this.urisToSearch = urisToSearch;
+        this.urisToSearch = Arrays.stream(urisToSearch).toList();
     }
 
     /**
@@ -44,7 +46,7 @@ public class JavadocViewerCommand implements Runnable {
     public JavadocViewer getJavadocViewer() {
         if (javadocViewer == null) {
             try {
-                javadocViewer = new JavadocViewer(stylesheet, urisToSearch);
+                javadocViewer = new JavadocViewer(stylesheet, urisToSearch.toArray(new URI[0]));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewerCommand.java
+++ b/javadocviewer/src/main/java/qupath/ui/javadocviewer/gui/viewer/JavadocViewerCommand.java
@@ -24,10 +24,10 @@ public class JavadocViewerCommand implements Runnable {
     /**
      * Create the command. This will not create the viewer until either the command is run or {@link #getJavadocViewer()} is called.
      *
-     * @param owner  the stage that should own the viewer window. Can be null
-     * @param stylesheet  a property containing a link to a stylesheet which should
-     *                    be applied to the viewer. Can be null
-     * @param urisToSearch  URIs to search for Javadocs. See {@link JavadocViewer#JavadocViewer(ReadOnlyStringProperty, URI...)}
+     * @param owner the stage that should own the viewer window. Can be null
+     * @param stylesheet a property containing a link to a stylesheet which should
+     *                   be applied to the viewer. Can be null
+     * @param urisToSearch URIs to search for Javadocs. See {@link JavadocViewer#JavadocViewer(ReadOnlyStringProperty, URI...)}
      */
     public JavadocViewerCommand(Stage owner, ReadOnlyStringProperty stylesheet, URI... urisToSearch) {
         this.owner = owner;


### PR DESCRIPTION
Improve the Javadoc search. I made a few choices that can be discussed:

* The search doesn't show any suggestions of package, module, variable, exception, annotation, or element.
* The search show suggestions in that order: class, interface, enum, constructor, static method, method.
* The filter has been changed:
  * If the suggestion is a class or an interface, its name is something like `some.package.Class`. The filter only looks at `Class`.
  * If the suggestion is an enum, its name is something like `some.package.Class.Enum` or `Class.Enum.variable`. The filter looks at `Class.Enum` or `Enum.variable`.
  * If the suggestion is a constructor, static method, or method, its name is something like `Class.Class(Parameter)` for constructors or `Class.function(Parameter)` for functions. The filter looks at `Class` or `function`.

I also did a bit of refactoring to improve error handling.